### PR TITLE
fix: remove "OBSESSED WITH SOLVING PROBLEMS." text from Hero component

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -65,10 +65,6 @@ const Hero = () => {
             <SplitHeading className="font-display text-display2 text-balance leading-none text-white mb-4">
               JUST BUILDING STUFF.
             </SplitHeading>
-            <RevealText
-              text="OBSESSED WITH SOLVING PROBLEMS."
-              className="text-yellow-light font-display text-h2 text-balance"
-            />
           </div>
 
           {/* Description */}
@@ -139,3 +135,4 @@ const Hero = () => {
 };
 
 export default Hero;
+


### PR DESCRIPTION
Removed the "OBSESSED WITH SOLVING PROBLEMS." text from the RevealText component in Hero.tsx as requested.

This change simplifies the hero section content by removing the specified text element.